### PR TITLE
Revert "Bump gatsby-plugin-react-helmet from 3.1.16 to 3.1.18 (#4)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7742,21 +7742,11 @@
       }
     },
     "gatsby-plugin-react-helmet": {
-      "version": "3.1.18",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.18.tgz",
-      "integrity": "sha512-wwKH6Z5NK0Gl2hDfMnWNGE41GjWpZGq0eKczPydTJc/1SbPykBFCBrjYgrAPB2ZrRnA8AV06cRwPddJC0mY7sw==",
+      "version": "3.1.16",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.16.tgz",
+      "integrity": "sha512-U8JL1o2WBYdr8x1qyA9FSFc1A6snYUuCW/WFqfYQjDcv6VFyPJhw5gQnmh5n+4yGcPhV3ktYDMSWKnXFegNu4A==",
       "requires": {
-        "@babel/runtime": "^7.7.6"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.7.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-          "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        }
+        "@babel/runtime": "^7.7.4"
       }
     },
     "gatsby-plugin-sharp": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gatsby-image": "^2.2.34",
     "gatsby-plugin-manifest": "^2.2.31",
     "gatsby-plugin-offline": "^3.0.27",
-    "gatsby-plugin-react-helmet": "^3.1.18",
+    "gatsby-plugin-react-helmet": "^3.1.16",
     "gatsby-plugin-sharp": "^2.3.5",
     "gatsby-source-filesystem": "^2.1.40",
     "gatsby-transformer-sharp": "^2.3.7",


### PR DESCRIPTION
This reverts commit 9bfc085afd26e620a4c0a5b3378e2915538650c5.