### PR TITLE
Revert "Bump gatsby-plugin-manifest from 2.2.31 to 2.2.34 (#5)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7693,33 +7693,14 @@
       }
     },
     "gatsby-plugin-manifest": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.34.tgz",
-      "integrity": "sha512-Jo6fXZpJ/QSejrSj9BTfRNikVDjx9FuuKzT4w7il8I6qKtnM4z/lYOIMxRWkAdlK7dj+fpUlbTeClWjhlKRWAQ==",
+      "version": "2.2.31",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.31.tgz",
+      "integrity": "sha512-kU49eQQ4HqIVjKa3aMOvKFoDIZD0MahHZg3KluNpgRDw89JgUMivfTrCoTYq364ZCjwRxqYVFIm2CFf5WPRkhQ==",
       "requires": {
-        "@babel/runtime": "^7.7.6",
-        "gatsby-core-utils": "^1.0.25",
+        "@babel/runtime": "^7.7.4",
+        "gatsby-core-utils": "^1.0.22",
         "semver": "^5.7.1",
-        "sharp": "^0.23.4"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.7.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-          "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "gatsby-core-utils": {
-          "version": "1.0.25",
-          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.25.tgz",
-          "integrity": "sha512-Pz5xueweH9qv5TIW7wwlTxI/CbyzkiE5xvgLicbHbU+InH+lCNt4VuvGP1gQcIRuHMCIbuVKSiVCC7jnxEbtrA==",
-          "requires": {
-            "ci-info": "2.0.0",
-            "node-object-hash": "^2.0.0"
-          }
-        }
+        "sharp": "^0.23.3"
       }
     },
     "gatsby-plugin-offline": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@fortawesome/react-fontawesome": "^0.1.8",
     "gatsby": "^2.18.12",
     "gatsby-image": "^2.2.34",
-    "gatsby-plugin-manifest": "^2.2.34",
+    "gatsby-plugin-manifest": "^2.2.31",
     "gatsby-plugin-offline": "^3.0.27",
     "gatsby-plugin-react-helmet": "^3.1.18",
     "gatsby-plugin-sharp": "^2.3.5",


### PR DESCRIPTION
This reverts commit f70a3f6320fee9fa980b13a2568996427917056b.